### PR TITLE
CTECH-3055: Rename Client to LusidClient

### DIFF
--- a/sdk/client/client.ts
+++ b/sdk/client/client.ts
@@ -111,11 +111,11 @@ class Oauth2 {
 
 /*
 To get connected with LUSID all you need to do is create a new client from
-the Client class below. This class handles storage of the location of each
+the LusidClient class below. This class handles storage of the location of each
 of the credentials, OAuth2.0 token refresh logic and is populated with every
 one of LUSIDs APIs and their methods.
 */
-export class Client {
+export class LusidClient {
   // The authentication method to use.
   private authMethod: AuthenticationMethod;
 

--- a/sdk/test/tutorials/clientBuilder.ts
+++ b/sdk/test/tutorials/clientBuilder.ts
@@ -1,4 +1,4 @@
-import { AuthenticationMethod, Client, Source } from '../../client/client'
+import { AuthenticationMethod, LusidClient, Source } from '../../client/client'
 
 
 if (process.env["FBN_ACCESS_TOKEN"]) {
@@ -7,7 +7,7 @@ if (process.env["FBN_ACCESS_TOKEN"]) {
   var authMethod = AuthenticationMethod.RefreshingToken
 };
 
-export var client = new Client(
+export var client = new LusidClient(
   [Source.Environment, 'FBN_TOKEN_URL'],
   [Source.Environment, 'FBN_USERNAME'],
   [Source.Environment, 'FBN_PASSWORD'],


### PR DESCRIPTION
# Pull Request Checklist

- [x] Read the [contributing guidelines](../blob/master/docs/CONTRIBUTING.md)
- [x] Tests pass
- [x] Raised the PR against the `develop` branch

# Description of the PR

Renamed client to LusidClient so we can add a model with the name Client, without causing typescript compile errors.